### PR TITLE
fix: allow lowercase policy severity (ENG-2347)

### DIFF
--- a/stacklet/client/sinistral/commands/scans.py
+++ b/stacklet/client/sinistral/commands/scans.py
@@ -97,12 +97,7 @@ class Create(ClientCommand):
                                         "properties": {
                                             "severity": {
                                                 "title": "Severity",
-                                                "enum": [
-                                                    "HIGH",
-                                                    "MEDIUM",
-                                                    "LOW",
-                                                    "UNKNOWN",
-                                                ],
+                                                "pattern": "^(?i)(high|medium|low|unknown)$",
                                                 "type": "string",
                                                 "description": "An enumeration.",
                                             }


### PR DESCRIPTION
Change the jsonschema to allow lowercase or mixed case policy severity.

Corresponding backend change at
https://github.com/stacklet/sinistral/pull/320.

Fixes: [ENG-2347](https://stacklet.atlassian.net/browse/ENG-2347)

[ENG-2347]: https://stacklet.atlassian.net/browse/ENG-2347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ