### PR TITLE
feat: revoke project & org creds (ENG-2661)

### DIFF
--- a/scripts/openapi.json
+++ b/scripts/openapi.json
@@ -1096,6 +1096,24 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "Org"
+        ],
+        "summary": "Revoke Credentials",
+        "description": "Revoke existing Organization Credentials.",
+        "operationId": "revoke_org_credentials_org_credentials_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
       }
     },
     "/projects": {
@@ -1760,6 +1778,50 @@
             "HTTPBearer": []
           }
         ]
+      },
+      "delete": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Revoke Credentials",
+        "description": "Revoke any existing Project Credentials.",
+        "operationId": "revoke_credentials_projects__name__credentials_delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            },
+            "name": "name",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
       }
     },
     "/": {
@@ -2132,7 +2194,7 @@
               "added": 0,
               "updated": 0,
               "removed": 0,
-              "started_at": "2023-09-11T22:49:18.302769"
+              "started_at": "2023-09-19T20:57:16.486859"
             }
           }
         }
@@ -2258,7 +2320,7 @@
               "added": 0,
               "updated": 0,
               "removed": 0,
-              "started_at": "2023-09-11T22:49:18.302297"
+              "started_at": "2023-09-19T20:57:16.486380"
             }
           }
         }
@@ -2338,7 +2400,6 @@
         "title": "Project",
         "required": [
           "name",
-          "client_id",
           "created_at",
           "updated_at"
         ],

--- a/stacklet/client/sinistral/cli.py
+++ b/stacklet/client/sinistral/cli.py
@@ -89,6 +89,13 @@ def show(ctx, *args, **kwargs):
             id_details = jwt.decode(id_token, options={"verify_signature": False})
             click.echo(context.fmt(id_details))
             click.echo()
+        access_token = context.get_access_token()
+        if access_token:
+            access_details = jwt.decode(
+                access_token, options={"verify_signature": False}
+            )
+            click.echo(context.fmt(access_details))
+            click.echo()
         click.echo(context.fmt(context.config.to_dict()))
 
 

--- a/stacklet/client/sinistral/commands/org.py
+++ b/stacklet/client/sinistral/commands/org.py
@@ -40,3 +40,17 @@ class RegenerateCredentials(ClientCommand):
     params = {}
     query_params = {}
     payload_params = {}
+
+
+@Org.commands.register("revoke-credentials")
+class RevokeCredentials(ClientCommand):
+    """
+    Revoke existing Organization Credentials.
+    """
+
+    command = "revoke_credentials"
+    method = "delete"
+    path = "/org/credentials"
+    params = {}
+    query_params = {}
+    payload_params = {}

--- a/stacklet/client/sinistral/commands/projects.py
+++ b/stacklet/client/sinistral/commands/projects.py
@@ -276,3 +276,17 @@ class RegenerateCredentials(ClientCommand):
     params = {"--name": {"required": True}}
     query_params = {}
     payload_params = {}
+
+
+@Projects.commands.register("revoke-credentials")
+class RevokeCredentials(ClientCommand):
+    """
+    Revoke any existing Project Credentials.
+    """
+
+    command = "revoke_credentials"
+    method = "delete"
+    path = "/projects/{name}/credentials"
+    params = {"--name": {"required": True}}
+    query_params = {}
+    payload_params = {}

--- a/stacklet/client/sinistral/commands/scans.py
+++ b/stacklet/client/sinistral/commands/scans.py
@@ -87,13 +87,11 @@ class Create(ClientCommand):
                                 "properties": {
                                     "name": {"title": "Name", "type": "string"},
                                     "resource": {
-                                        "oneOf": [
-                                            {"title": "Resource", "type": "string"},
-                                            {
-                                                "type": "array",
-                                                "items": {"type": "string"},
-                                            },
-                                        ]
+                                        "title": "Resource",
+                                        "anyOf": [
+                                            {"type": "string"},
+                                            {"type": "array", "items": {}},
+                                        ],
                                     },
                                     "description": {
                                         "title": "Description",
@@ -105,7 +103,12 @@ class Create(ClientCommand):
                                         "properties": {
                                             "severity": {
                                                 "title": "Severity",
-                                                "pattern": "(?i)^(high|medium|low|unknown)$",
+                                                "enum": [
+                                                    "HIGH",
+                                                    "MEDIUM",
+                                                    "LOW",
+                                                    "UNKNOWN",
+                                                ],
                                                 "type": "string",
                                                 "description": "An enumeration.",
                                             }


### PR DESCRIPTION
Updates the API doc and adds commands for revoking Project and Org Credentials.

Depends on: https://github.com/stacklet/sinistral/pull/335
Depends on: https://github.com/stacklet/sinistral/pull/336