### PR TITLE
feat: auto-auth with project or org creds (ENG-2669)

### DIFF
--- a/stacklet/client/sinistral/cli.py
+++ b/stacklet/client/sinistral/cli.py
@@ -5,7 +5,7 @@ import jwt
 
 from pathlib import Path
 
-from stacklet.client.sinistral.cognito import CognitoClientAuth, CognitoUserManager
+from stacklet.client.sinistral.cognito import CognitoUserManager
 from stacklet.client.sinistral.commands import commands
 from stacklet.client.sinistral.config import StackletConfig
 from stacklet.client.sinistral.context import StackletContext
@@ -142,22 +142,12 @@ def login(ctx, username, password, *args, **kwargs):
 
         # Otherwise, prefer non-interactive auth to interactive.
         if context.can_project_auth():
-            client = CognitoClientAuth(ctx)
-            token = client.get_access_token(
-                context.config.auth_url,
-                context.config.project_client_id,
-                context.config.project_client_secret,
-            )
+            token = context.do_project_auth()
             context.write_access_token(token)
             return
 
         if context.can_org_auth():
-            client = CognitoClientAuth(ctx)
-            token = client.get_access_token(
-                context.config.auth_url,
-                context.config.org_client_id,
-                context.config.org_client_secret,
-            )
+            token = context.do_org_auth()
             context.write_access_token(token)
             return
 

--- a/stacklet/client/sinistral/client.py
+++ b/stacklet/client/sinistral/client.py
@@ -182,6 +182,8 @@ class SinistralClient:
     ):
         with self.ctx as context:
             token = context.get_access_token()
+            if not token:
+                raise Exception("Unauthorized, check credentials")
             executor = RestExecutor(context, token)
             func = getattr(executor, method)
             if isinstance(_json, str):

--- a/stacklet/client/sinistral/commands/run.py
+++ b/stacklet/client/sinistral/commands/run.py
@@ -74,10 +74,14 @@ def run(ctx, project, dryrun, *args, **kwargs):
     policy_collections_client = sinistral.client("policy-collections")
 
     results = []
-    project_data = projects_client.get(name=SinistralFormat.project)
+    try:
+        project_data = projects_client.get(name=SinistralFormat.project)
+    except Exception as e:
+        click.echo(f"Unable to get project: {e}", err=True)
+        sys.exit(1)
 
     if not project_data.get("collections"):
-        click.echo("Project has no policy collections")
+        click.echo("Project has no policy collections", err=True)
         sys.exit(1)
 
     for c in project_data["collections"]:


### PR DESCRIPTION
Adds support to automatically use Project or Org Credentials if available in the environment to get an in-memory access token if an on-disk one is not available. This can streamline the process for headless usage in CI systems and entirely avoid the need to manage a SINISTRAL_CONFIG dir.