### PR TITLE
feat: automatically create project (ENG-2685)

### DIFF
--- a/stacklet/client/sinistral/commands/run.py
+++ b/stacklet/client/sinistral/commands/run.py
@@ -80,9 +80,8 @@ def run(ctx, project, dryrun, *args, **kwargs):
         try:
             policies = projects_client.get_policies(name=project)
         except Exception as e:
-            # try to auto-create project if not found
-            if "not found" in str(e):
-                # TODO: should we support default user groups as well?
+            # try to auto-create project if not found, but only for org auth
+            if "not found" in str(e) and sinistral.ctx.is_org_auth:
                 projects_client.create(name=project, groups={"read": []})
                 policies = projects_client.get_policies(name=project)
             else:

--- a/stacklet/client/sinistral/commands/run.py
+++ b/stacklet/client/sinistral/commands/run.py
@@ -48,7 +48,6 @@ def run(ctx, project, dryrun, *args, **kwargs):
     """
     Run a policy and report to sinistral
     """
-
     if project and ctx.params.get("policy_dir"):
         raise click.UsageError("Either project or policy directory must be specified")
 
@@ -76,26 +75,32 @@ def run(ctx, project, dryrun, *args, **kwargs):
     sinistral = sinistral_client()
 
     projects_client = sinistral.client("projects")
-    policy_collections_client = sinistral.client("policy-collections")
 
-    results = []
     try:
-        project_data = projects_client.get(name=project)
+        try:
+            policies = projects_client.get_policies(name=project)
+        except Exception as e:
+            # try to auto-create project if not found
+            if "not found" in str(e):
+                # TODO: should we support default user groups as well?
+                projects_client.create(name=project, groups={"read": []})
+                policies = projects_client.get_policies(name=project)
+            else:
+                raise
     except Exception as e:
         click.echo(f"Unable to get project: {e}", err=True)
         sys.exit(1)
 
-    if not project_data.get("collections"):
+    if not policies:
         click.echo("Project has no policy collections", err=True)
         sys.exit(1)
 
-    for c in project_data["collections"]:
-        policies = policy_collections_client.get_policies(name=c)
-        raw_policies = [p["raw_policy"] for p in policies]
-        with TemporaryDirectory() as tempdir:
-            with open(f"{tempdir}/policy.yaml", "w+") as f:
-                yaml.dump({"policies": raw_policies}, f)
-                ctx.params["policy_dir"] = tempdir
-                results.append(int(left_run.invoke(ctx)))
+    raw_policies = [p["raw_policy"] for p in policies]
+    results = []
+    with TemporaryDirectory() as tempdir:
+        with open(f"{tempdir}/policy.yaml", "w+") as f:
+            yaml.dump({"policies": raw_policies}, f)
+            ctx.params["policy_dir"] = tempdir
+            results.append(int(left_run.invoke(ctx)))
 
     sys.exit(int(sorted(results)[-1]))

--- a/stacklet/client/sinistral/context.py
+++ b/stacklet/client/sinistral/context.py
@@ -28,6 +28,9 @@ class StackletContext:
         self.access_token_path = base_path / self.CREDENTIALS_FILE
         self.id_token_path = base_path / self.ID_FILE
 
+        self._is_org_auth = False
+        self._is_project_auth = False
+
     def get_access_token(self):
         if StackletContext._ACCESS_TOKEN:
             return StackletContext._ACCESS_TOKEN
@@ -96,7 +99,12 @@ class StackletContext:
             self.config.project_client_id,
             self.config.project_client_secret,
         )
+        self._is_project_auth = True
         return token
+
+    @property
+    def is_project_auth(self):
+        return self._is_project_auth
 
     def can_org_auth(self):
         return all(
@@ -113,7 +121,12 @@ class StackletContext:
             self.config.org_client_id,
             self.config.org_client_secret,
         )
+        self._is_org_auth = True
         return token
+
+    @property
+    def is_org_auth(self):
+        return self._is_org_auth
 
 
 class StackletCredentialWriter:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -109,7 +109,7 @@ def test_api_error(runner, mock_rest):
     result = runner("run", "--project", "foo", "-d", path)
 
     assert result.exit_code == 1
-    assert result.output.strip() == "test"
+    assert result.output.strip() == "Unable to get project: test"
     assert not mock_rest.post.called
 
 
@@ -147,4 +147,4 @@ def test_project_auto_create_non_org_auth(runner, mock_rest):
     result = runner("run", "--project", "foo", "-d", path)
 
     assert result.exit_code == 1
-    assert result.output.strip() == "Project foo not found"
+    assert result.output.strip() == "Unable to get project: Project foo not found"


### PR DESCRIPTION
Adds support for `sinistral run` to automatically create the given project if it does not exist. Assumes https://github.com/stacklet/sinistral/pull/338 but does not depend on it.