### PR TITLE
fix: fix project name param for run command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "stacklet.client.sinistral"
-version = "0.2.6"
+version = "0.2.7"
 description = "Sinistral CLI"
 authors = ["Sonny Shi <sonny@stacklet.io>"]
 maintainers = ["Stacklet <hello@stacklet.io>"]

--- a/stacklet/client/sinistral/commands/run.py
+++ b/stacklet/client/sinistral/commands/run.py
@@ -80,7 +80,7 @@ def run(ctx, project, dryrun, *args, **kwargs):
 
     results = []
     try:
-        project_data = projects_client.get(name=SinistralFormat.project)
+        project_data = projects_client.get(name=project)
     except Exception as e:
         click.echo(f"Unable to get project: {e}", err=True)
         sys.exit(1)


### PR DESCRIPTION
The change in #37 (specifically, [this line](https://github.com/stacklet/sinistral-cli/pull/37/files#diff-ef633b1c3ca97ad0e780e8a0e54ab94bd41b7df89977f2d8b3a2de239d9821eeL67)) means that the SinistralFormat class attribute will never be set, so we should use the local var instead.