### PR TITLE
chore: update to latest sigstore action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,7 +66,7 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v1.2.3
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
           inputs: >-
             ./dist/*.tar.gz


### PR DESCRIPTION
The most recent run failed (https://github.com/stacklet/sinistral-cli/actions/runs/11036748647/job/30655998896), update to latest version.